### PR TITLE
Update to spring-data-mongodb 2.X

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -7,7 +7,7 @@
     <artifactId>spring-data-mongodb-encrypt</artifactId>
     <packaging>jar</packaging>
     <name>spring-data-mongodb-encrypt</name>
-    <version>1.3.0</version>
+    <version>2.0.0-SNAPSHOT</version>
     <description>High performance, per-field encryption for spring-data-mongodb</description>
     <url>https://github.com/agoston/spring-data-mongodb-encrypt</url>
 
@@ -51,14 +51,14 @@
         <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-mongodb</artifactId>
-            <version>1.10.4.RELEASE</version>
+            <version>2.0.4.RELEASE</version>
             <scope>provided</scope>
         </dependency>
         <!-- test -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <version>1.5.4.RELEASE</version>
+            <version>2.0.4.RELEASE</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/src/main/java/com/bol/secure/AbstractEncryptionEventListener.java
+++ b/src/main/java/com/bol/secure/AbstractEncryptionEventListener.java
@@ -18,7 +18,8 @@ public class AbstractEncryptionEventListener extends AbstractMongoEventListener 
 
     class Decoder extends BasicBSONDecoder implements Function<Object, Object> {
         public Object apply(Object o) {
-            byte[] serialized = cryptVault.decrypt((byte[]) o);
+            byte[] data = ((Binary) o).getData();
+            byte[] serialized = cryptVault.decrypt((data));
             BSONCallback bsonCallback = new BasicDBObjectCallback();
             decode(serialized, bsonCallback);
             BSONObject deserialized = (BSONObject) bsonCallback.get();
@@ -26,7 +27,9 @@ public class AbstractEncryptionEventListener extends AbstractMongoEventListener 
         }
     }
 
-    /** BasicBSONEncoder returns BasicBSONObject which makes mongotemplate converter choke :( */
+    /**
+     * BasicBSONEncoder returns BasicBSONObject which makes mongotemplate converter choke :(
+     */
     class BasicDBObjectCallback extends BasicBSONCallback {
         @Override
         public BSONObject create() {

--- a/src/main/java/com/bol/secure/CachedEncryptionEventListener.java
+++ b/src/main/java/com/bol/secure/CachedEncryptionEventListener.java
@@ -2,9 +2,7 @@ package com.bol.secure;
 
 import com.bol.crypt.CryptVault;
 import com.bol.reflection.Node;
-import com.mongodb.BasicDBList;
-import com.mongodb.BasicDBObject;
-import com.mongodb.DBObject;
+import org.bson.Document;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 import org.springframework.data.mongodb.core.mapping.event.AfterLoadEvent;
@@ -19,7 +17,8 @@ import java.util.function.Function;
 import static com.bol.reflection.ReflectionCache.processDocument;
 
 public class CachedEncryptionEventListener extends AbstractEncryptionEventListener {
-    @Autowired MongoMappingContext mappingContext;
+    @Autowired
+    MongoMappingContext mappingContext;
 
     Map<Class, Node> encrypted;
 
@@ -39,55 +38,78 @@ public class CachedEncryptionEventListener extends AbstractEncryptionEventListen
 
     @Override
     public void onAfterLoad(AfterLoadEvent event) {
-        DBObject dbObject = event.getDBObject();
+        Document document = event.getDocument();
 
         Node node = encrypted.get(event.getType());
         if (node == null) return;
 
-        cryptFields(dbObject, node, new Decoder());
+        cryptFields(document, node, new Decoder());
     }
 
     @Override
     public void onBeforeSave(BeforeSaveEvent event) {
-        DBObject dbObject = event.getDBObject();
+        Document document = event.getDocument();
 
         Node node = encrypted.get(event.getSource().getClass());
         if (node == null) return;
 
-        cryptFields(dbObject, node, new Encoder());
+        cryptFields(document, node, new Encoder());
     }
 
-    void cryptFields(DBObject dbObject, Node node, Function<Object, Object> crypt) {
-        if (node.type == Node.Type.MAP) {
-            Node mapChildren = node.children.get(0);
-            for (Object entry : ((BasicDBObject) dbObject).values()) {
-                cryptFields((DBObject) entry, mapChildren, crypt);
-            }
-            return;
 
-        } else if (node.type == Node.Type.LIST) {
-            Node mapChildren = node.children.get(0);
-            for (Object entry : (BasicDBList) dbObject) {
-                cryptFields((DBObject) entry, mapChildren, crypt);
-            }
-            return;
+    void cryptFields(Object o, Node node, Function<Object, Object> crypt) {
+        if (o instanceof Document) {
+            cryptField((Document) o, node, crypt);
+        } else if (o instanceof List) {
+            cryptField((List) o, node, crypt);
+        } else {
+            throw new IllegalArgumentException("Unknown class field to crypt " + o.getClass());
         }
+    }
 
+    void cryptField(List list, Node node, Function<Object, Object> crypt) {
+        if (node.type == Node.Type.LIST) {
+
+            Node mapChildren = node.children.get(0);
+            for (Object entry : list) {
+                cryptFields(entry, mapChildren, crypt);
+            }
+            return;
+        } else {
+            throw new IllegalArgumentException("Unmatching node type for a List object " + node.type);
+        }
+    }
+
+
+    void cryptField(Document document, Node node, Function<Object, Object> crypt) {
+        if (node.type == Node.Type.MAP) {
+
+            Node mapChildren = node.children.get(0);
+            for (Object entry : document.values()) {
+
+                cryptFields(entry, mapChildren, crypt);
+            }
+            return;
+
+        }
         for (Node childNode : node.children) {
-            Object value = dbObject.get(childNode.fieldName);
+            Object value = document.get(childNode.fieldName);
+
             if (value == null) continue;
 
             if (!childNode.children.isEmpty()) {
-                if (value instanceof BasicDBList) {
-                    for (Object o : (BasicDBList) value)
-                        cryptFields((DBObject) o, childNode.children.get(0), crypt);
+                if (value instanceof List) {
+                    for (Object o : (List) value) {
+                        cryptFields(o, childNode.children.get(0), crypt);
+                    }
                 } else {
-                    cryptFields((BasicDBObject) value, childNode, crypt);
+                    cryptFields(value, childNode, crypt);
                 }
                 return;
             }
 
-            dbObject.put(childNode.fieldName, crypt.apply(value));
+            document.put(childNode.fieldName, crypt.apply(value));
         }
     }
+
 }

--- a/src/main/java/com/bol/secure/ReflectionEncryptionEventListener.java
+++ b/src/main/java/com/bol/secure/ReflectionEncryptionEventListener.java
@@ -1,9 +1,7 @@
 package com.bol.secure;
 
 import com.bol.crypt.CryptVault;
-import com.mongodb.BasicDBList;
-import com.mongodb.DBObject;
-import org.bson.types.BasicBSONList;
+import org.bson.Document;
 import org.springframework.data.mongodb.core.mapping.event.AfterLoadEvent;
 import org.springframework.data.mongodb.core.mapping.event.BeforeSaveEvent;
 import org.springframework.util.ReflectionUtils;
@@ -11,7 +9,9 @@ import org.springframework.util.ReflectionUtils;
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -20,20 +20,8 @@ public class ReflectionEncryptionEventListener extends AbstractEncryptionEventLi
         super(cryptVault);
     }
 
-    @Override
-    public void onAfterLoad(AfterLoadEvent event) {
-        DBObject dbObject = event.getDBObject();
-        cryptFields(dbObject, event.getType(), new Decoder());
-    }
-
-    @Override
-    public void onBeforeSave(BeforeSaveEvent event) {
-        DBObject dbObject = event.getDBObject();
-        cryptFields(dbObject, event.getSource().getClass(), new Encoder());
-    }
-
-    static void cryptFields(DBObject dbObject, Class node, Function<Object, Object> crypt) {
-        for (String fieldName : dbObject.keySet()) {
+    static void cryptFields(Document document, Class node, Function<Object, Object> crypt) {
+        for (String fieldName : document.keySet()) {
             if (fieldName.equals("_class")) continue;
 
             Field field = ReflectionUtils.findField(node, fieldName);
@@ -41,8 +29,8 @@ public class ReflectionEncryptionEventListener extends AbstractEncryptionEventLi
 
             if (field.isAnnotationPresent(Encrypted.class)) {
                 // direct encryption
-                Object value = dbObject.get(fieldName);
-                dbObject.put(fieldName, crypt.apply(value));
+                Object value = document.get(fieldName);
+                document.put(fieldName, crypt.apply(value));
 
             } else {
 
@@ -51,33 +39,43 @@ public class ReflectionEncryptionEventListener extends AbstractEncryptionEventLi
                 if (Collection.class.isAssignableFrom(fieldType)) {
                     ParameterizedType parameterizedType = (ParameterizedType) field.getGenericType();
                     Type subFieldType = parameterizedType.getActualTypeArguments()[0];
-                    BasicDBList list = (BasicDBList) dbObject.get(fieldName);
+                    ArrayList list = (ArrayList) document.get(fieldName);
                     for (Object o : list) {
-                        diveInto(crypt, (DBObject) o, subFieldType);
+                        diveIntoGeneric(crypt, o, subFieldType);
                     }
 
                 } else if (Map.class.isAssignableFrom(fieldType)) {
                     ParameterizedType parameterizedType = (ParameterizedType) field.getGenericType();
                     Type subFieldType = parameterizedType.getActualTypeArguments()[1];
-                    DBObject map = (DBObject) dbObject.get(fieldName);
+                    Document map = (Document) document.get(fieldName);
                     for (String key : map.keySet()) {
-                        diveInto(crypt, (DBObject) map.get(key), subFieldType);
+                        diveIntoGeneric(crypt, map.get(key), subFieldType);
                     }
                 } else {
-                    Object o = dbObject.get(fieldName);
-                    if (o instanceof DBObject) {
-                        // descending into sub-documents
-                        DBObject subObject = (DBObject) o;
-                        diveInto(crypt, subObject, fieldType);
+                    Object o = document.get(fieldName);
 
+                    if (o instanceof Document) {
+                        // descending into sub-documents
+                        Document subObject = (Document) o;
+                        diveIntoGeneric(crypt, subObject, fieldType);
                     }
-                    // otherwise, it's a primitive - ignore
                 }
             }
         }
     }
 
-    static void diveInto(Function<Object, Object> crypt, DBObject value, Type fieldType) {
+
+    static void diveIntoGeneric(Function<Object, Object> crypt, Object value, Type fieldType) {
+        if (value instanceof Document)
+            diveInto(crypt, (Document) value, fieldType);
+        else if (value instanceof List)
+            diveInto(crypt, (List) value, fieldType);
+        else
+            throw new IllegalArgumentException("Unknown reflective value class " + value.getClass());
+    }
+
+
+    static void diveInto(Function<Object, Object> crypt, Document value, Type fieldType) {
         Class<?> childNode = fetchClassFromField(value);
         if (childNode != null) {
             cryptFields(value, childNode, crypt);
@@ -88,21 +86,21 @@ public class ReflectionEncryptionEventListener extends AbstractEncryptionEventLi
         if (fieldType instanceof Class) {
             childNode = (Class) fieldType;
             cryptFields(value, childNode, crypt);
+        } else {
+            throw new IllegalArgumentException("Unknown reflective type class " + fieldType.getClass());
+        }
+    }
 
-        } else if (fieldType instanceof ParameterizedType) {
+    static void diveInto(Function<Object, Object> crypt, List value, Type fieldType) {
+        if (fieldType instanceof ParameterizedType) {
             ParameterizedType subType = (ParameterizedType) fieldType;
             Class rawType = (Class) subType.getRawType();
 
             if (Collection.class.isAssignableFrom(rawType)) {
                 Type subFieldType = subType.getActualTypeArguments()[0];
-                BasicDBList list = (BasicDBList) value;
-                for (Object o : list) diveInto(crypt, (DBObject) o, subFieldType);
 
-            } else if (Map.class.isAssignableFrom(rawType)) {
-                Type subFieldType = subType.getActualTypeArguments()[1];
-                for (String key : value.keySet()) {
-                    diveInto(crypt, (DBObject) value.get(key), subFieldType);
-                }
+                for (Object o : value)
+                    diveIntoGeneric(crypt, o, subFieldType);
 
             } else {
                 throw new IllegalArgumentException("Unknown reflective raw type class " + rawType.getClass() + "; should be Map<> or Collection<>");
@@ -112,16 +110,27 @@ public class ReflectionEncryptionEventListener extends AbstractEncryptionEventLi
         }
     }
 
-    private static Class<?> fetchClassFromField(DBObject value) {
-        // mongo-java-driver's basicbsonlist is one dirty hack :(
-        if (value instanceof BasicBSONList) return null;
-
+    private static Class<?> fetchClassFromField(Document value) {
         String className = (String) value.get("_class");
         if (className != null) {
             try {
                 return Class.forName(className);
-            } catch (ClassNotFoundException ignored) { }
+            } catch (ClassNotFoundException ignored) {
+            }
         }
         return null;
+    }
+
+    @Override
+    public void onAfterLoad(AfterLoadEvent event) {
+        Document document = event.getDocument();
+        cryptFields(document, event.getType(), new Decoder());
+    }
+
+    @Override
+    public void onBeforeSave(BeforeSaveEvent event) {
+        Document document = event.getDocument();
+        cryptFields(document, event.getSource().getClass(), new Encoder());
+
     }
 }

--- a/src/test/java/com/bol/system/CryptVersionSystemTest.java
+++ b/src/test/java/com/bol/system/CryptVersionSystemTest.java
@@ -2,8 +2,8 @@ package com.bol.system;
 
 import com.bol.crypt.CryptVault;
 import com.bol.system.cached.CachedMongoDBConfiguration;
-import com.mongodb.BasicDBObject;
-import com.mongodb.DBObject;
+import org.bson.Document;
+import org.bson.types.Binary;
 import org.bson.types.ObjectId;
 import org.junit.Before;
 import org.junit.Test;
@@ -25,13 +25,17 @@ import static org.junit.Assert.assertThat;
 import static org.springframework.data.mongodb.core.query.Criteria.where;
 import static org.springframework.data.mongodb.core.query.Query.query;
 
-/** needs mongodb running locally */
+/**
+ * needs mongodb running locally
+ */
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = {CachedMongoDBConfiguration.class})
 public class CryptVersionSystemTest {
 
-    @Autowired MongoTemplate mongoTemplate;
-    @Autowired CryptVault cryptVault;
+    @Autowired
+    MongoTemplate mongoTemplate;
+    @Autowired
+    CryptVault cryptVault;
 
     @Before
     public void setup() {
@@ -86,9 +90,11 @@ public class CryptVersionSystemTest {
         bean.nonSensitiveData = getClass().getSimpleName();
         mongoTemplate.insert(bean);
 
-        DBObject fromMongo = mongoTemplate.getCollection(MyBean.MONGO_MYBEAN).find(new BasicDBObject("_id", new ObjectId(bean.id))).next();
+        Document fromMongo = mongoTemplate.getCollection(MyBean.MONGO_MYBEAN).find(new Document("_id", new ObjectId(bean.id))).first();
         Object cryptedSecret = fromMongo.get(MONGO_SECRETSTRING);
-        assertThat(cryptedSecret, is(instanceOf(byte[].class)));
-        return (byte[]) cryptedSecret;
+        assertThat(cryptedSecret, is(instanceOf(Binary.class)));
+        Object cryptedSecretData = ((Binary) cryptedSecret).getData();
+        assertThat(cryptedSecretData, is(instanceOf(byte[].class)));
+        return (byte[]) cryptedSecretData;
     }
 }

--- a/src/test/java/com/bol/system/MongoDBConfiguration.java
+++ b/src/test/java/com/bol/system/MongoDBConfiguration.java
@@ -1,9 +1,6 @@
 package com.bol.system;
 
 import com.bol.crypt.CryptVault;
-import com.mongodb.Mongo;
-import com.mongodb.MongoClient;
-import com.mongodb.ServerAddress;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -18,7 +15,8 @@ public abstract class MongoDBConfiguration extends AbstractMongoConfiguration {
 
     private static final byte[] secretKey = Base64.getDecoder().decode("hqHKBLV83LpCqzKpf8OvutbCs+O5wX5BPu3btWpEvXA=");
 
-    @Value("${mongodb.port:27017}") int port;
+    @Value("${mongodb.port:27017}")
+    int port;
 
     @Override
     protected String getDatabaseName() {
@@ -28,12 +26,6 @@ public abstract class MongoDBConfiguration extends AbstractMongoConfiguration {
     @Override
     protected Collection<String> getMappingBasePackages() {
         return Collections.singletonList(MongoDBConfiguration.class.getPackage().getName());
-    }
-
-    @Override
-    @Bean
-    public Mongo mongo() throws Exception {
-        return new MongoClient(new ServerAddress("localhost", port));
     }
 
     @Bean

--- a/src/test/java/com/bol/system/MyBean.java
+++ b/src/test/java/com/bol/system/MyBean.java
@@ -88,6 +88,9 @@ public class MyBean {
     public List<List<MySubBean>> nestedListList;
 
     @Field
+    public List<List<MySubBeanNotEncrypted>> nestedListListNotEncrypted;
+
+    @Field
     @Version
     public Long version;
 }

--- a/src/test/java/com/bol/system/MySubBeanNotEncrypted.java
+++ b/src/test/java/com/bol/system/MySubBeanNotEncrypted.java
@@ -1,0 +1,19 @@
+package com.bol.system;
+
+import org.springframework.data.mongodb.core.mapping.Field;
+
+public class MySubBeanNotEncrypted {
+    public static final String MONGO_NONSENSITIVEDATA1 = "nonSensitiveData1";
+    public static final String MONGO_NONSENSITIVEDATA2 = "nonSensitiveData2";
+
+    @Field
+    public String nonSensitiveData1;
+
+    @Field
+    public String nonSensitiveData2;
+
+    public MySubBeanNotEncrypted(String nonSensitiveData1, String nonSensitiveData2) {
+        this.nonSensitiveData1 = nonSensitiveData1;
+        this.nonSensitiveData2 = nonSensitiveData2;
+    }
+}

--- a/src/test/java/com/bol/system/cached/CachedMongoDBConfiguration.java
+++ b/src/test/java/com/bol/system/cached/CachedMongoDBConfiguration.java
@@ -3,6 +3,7 @@ package com.bol.system.cached;
 import com.bol.crypt.CryptVault;
 import com.bol.secure.CachedEncryptionEventListener;
 import com.bol.system.MongoDBConfiguration;
+import com.mongodb.MongoClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,5 +12,10 @@ public class CachedMongoDBConfiguration extends MongoDBConfiguration {
     @Bean
     public CachedEncryptionEventListener encryptionEventListener(CryptVault cryptVault) {
         return new CachedEncryptionEventListener(cryptVault);
+    }
+
+    @Override
+    public MongoClient mongoClient() {
+        return new MongoClient();
     }
 }

--- a/src/test/java/com/bol/system/reflection/ReflectionMongoDBConfiguration.java
+++ b/src/test/java/com/bol/system/reflection/ReflectionMongoDBConfiguration.java
@@ -3,6 +3,7 @@ package com.bol.system.reflection;
 import com.bol.crypt.CryptVault;
 import com.bol.secure.ReflectionEncryptionEventListener;
 import com.bol.system.MongoDBConfiguration;
+import com.mongodb.MongoClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,5 +12,10 @@ public class ReflectionMongoDBConfiguration extends MongoDBConfiguration {
     @Bean
     public ReflectionEncryptionEventListener encryptionEventListener(CryptVault cryptVault) {
         return new ReflectionEncryptionEventListener(cryptVault);
+    }
+
+    @Override
+    public MongoClient mongoClient() {
+        return new MongoClient();
     }
 }


### PR DESCRIPTION
Hello,

I've forked and updated your module to run it with springboot 2.X.
Most of the work was to replace `dbObjects` by `Document` and `Lists`. However, there are still some mismatches, like saving and loading `List` and `byte[]`, see also : https://jira.mongodb.org/browse/JAVA-2025 .

Also, there is one test not working with spring-data-mongodb 2.X. Mongo template cannot load a Bean within a list, within a list. I've added a test to highlight this error.

And sorry to bother, but I've got little to zero experience with apache licence 2.0, should I do something else in the documentation, or add something about contributors?

Anyway, I hope it'll work for you, feel free to ask me if there is some odd changes.

Regards