### PR TITLE
The AbstractMongoConfiguration interface has been deprecated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Configure spring (or see [how tests set up spring mongodb context](src/test/java
 
 ```java
 @Configuration
-public class MongoDBConfiguration extends AbstractMongoConfiguration {
+public class MongoDBConfiguration extends AbstractMongoClientConfiguration {
 
     // normally you would use @Value to wire a property here
     private static final byte[] secretKey = Base64.getDecoder().decode("hqHKBLV83LpCqzKpf8OvutbCs+O5wX5BPu3btWpEvXA=");
@@ -50,9 +50,8 @@ public class MongoDBConfiguration extends AbstractMongoConfiguration {
     }
 
     @Override
-    @Bean
-    public Mongo mongo() throws Exception {
-        return new MongoClient();
+    public MongoClient mongoClient() {
+        return MongoClients.create();
     }
 
     @Bean

--- a/pom.xml
+++ b/pom.xml
@@ -51,14 +51,14 @@
         <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-mongodb</artifactId>
-            <version>2.1.11.RELEASE</version>
+            <version>2.2.4.RELEASE</version>
             <scope>provided</scope>
         </dependency>
         <!-- test -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <version>2.0.5.RELEASE</version>
+            <version>2.2.4.RELEASE</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/src/test/java/com/bol/system/MongoDBConfiguration.java
+++ b/src/test/java/com/bol/system/MongoDBConfiguration.java
@@ -1,18 +1,19 @@
 package com.bol.system;
 
 import com.bol.crypt.CryptVault;
-import com.mongodb.MongoClient;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.mongodb.config.AbstractMongoConfiguration;
+import org.springframework.data.mongodb.config.AbstractMongoClientConfiguration;
 
 import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 
 @Configuration
-public abstract class MongoDBConfiguration extends AbstractMongoConfiguration {
+public abstract class MongoDBConfiguration extends AbstractMongoClientConfiguration {
 
     private static final byte[] secretKey = Base64.getDecoder().decode("hqHKBLV83LpCqzKpf8OvutbCs+O5wX5BPu3btWpEvXA=");
 
@@ -31,7 +32,8 @@ public abstract class MongoDBConfiguration extends AbstractMongoConfiguration {
 
     @Override
     public MongoClient mongoClient() {
-        return new MongoClient("localhost", port);
+        String connectionString = "mongodb://localhost:" + port;
+        return MongoClients.create(connectionString);
     }
 
     @Bean


### PR DESCRIPTION
This pull request changes the tests to use `AbstractMongoClientConfiguration` instead of `AbstractMongoConfiguration` since the latter has been deprecated.

Aside: This library was very easy to use. Thanks!