### PR TITLE
the strategy of detecting whether the field should be encrypted was extracted

### DIFF
--- a/src/main/java/com/bol/reflection/FieldEncryptedPredicate.java
+++ b/src/main/java/com/bol/reflection/FieldEncryptedPredicate.java
@@ -1,0 +1,12 @@
+package com.bol.reflection;
+
+import com.bol.secure.Encrypted;
+
+import java.lang.reflect.Field;
+import java.util.function.Predicate;
+
+public interface FieldEncryptedPredicate extends Predicate<Field> {
+
+  FieldEncryptedPredicate ANNOTATION_PRESENT = field -> field.isAnnotationPresent(Encrypted.class);
+
+}

--- a/src/main/java/com/bol/reflection/ReflectionCache.java
+++ b/src/main/java/com/bol/reflection/ReflectionCache.java
@@ -1,6 +1,6 @@
 package com.bol.reflection;
 
-import com.bol.secure.Encrypted;
+import com.bol.secure.FieldEncryptedPredicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.mongodb.core.mapping.Field;
@@ -12,7 +12,7 @@ import java.lang.reflect.Type;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static com.bol.reflection.FieldEncryptedPredicate.ANNOTATION_PRESENT;
+import static com.bol.secure.FieldEncryptedPredicate.ANNOTATION_PRESENT;
 
 public class ReflectionCache {
 
@@ -111,7 +111,7 @@ public class ReflectionCache {
 
                 String documentName = parseFieldAnnotation(field, fieldName);
 
-                if (field.isAnnotationPresent(Encrypted.class)) {
+                if (fieldEncryptedPredicate.test(field)) {
                     // direct @Encrypted annotation - crypt the corresponding field of BasicDbObject
                     nodes.add(new Node(fieldName, documentName, Collections.emptyList(), Node.Type.DIRECT, field));
 

--- a/src/main/java/com/bol/reflection/ReflectionCache.java
+++ b/src/main/java/com/bol/reflection/ReflectionCache.java
@@ -12,11 +12,23 @@ import java.lang.reflect.Type;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static com.bol.reflection.FieldEncryptedPredicate.ANNOTATION_PRESENT;
+
 public class ReflectionCache {
 
     private static final Logger LOG = LoggerFactory.getLogger(ReflectionCache.class);
 
-    private ConcurrentHashMap<Class, List<Node>> reflectionCache = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Class, List<Node>> reflectionCache = new ConcurrentHashMap<>();
+
+    private final FieldEncryptedPredicate fieldEncryptedPredicate;
+
+    public ReflectionCache() {
+        this(ANNOTATION_PRESENT);
+    }
+
+    public ReflectionCache(FieldEncryptedPredicate fieldEncryptedPredicate) {
+        this.fieldEncryptedPredicate = fieldEncryptedPredicate;
+    }
 
     // used by CachedEncryptionEventListener to gather metadata of a class and all it fields, recursively.
     public List<Node> reflectRecursive(Class objectClass) {
@@ -48,7 +60,7 @@ public class ReflectionCache {
 
                 String documentName = parseFieldAnnotation(field, fieldName);
 
-                if (field.isAnnotationPresent(Encrypted.class)) {
+                if (fieldEncryptedPredicate.test(field)) {
                     // direct @Encrypted annotation - crypt the corresponding field of BasicDbObject
                     nodes.add(new Node(fieldName, documentName, Collections.emptyList(), Node.Type.DIRECT, field));
 

--- a/src/main/java/com/bol/secure/CachedEncryptionEventListener.java
+++ b/src/main/java/com/bol/secure/CachedEncryptionEventListener.java
@@ -3,6 +3,7 @@ package com.bol.secure;
 import com.bol.crypt.CryptVault;
 import com.bol.crypt.DocumentCryptException;
 import com.bol.crypt.FieldCryptException;
+import com.bol.reflection.FieldEncryptedPredicate;
 import com.bol.reflection.Node;
 import com.bol.reflection.ReflectionCache;
 import org.bson.Document;
@@ -18,10 +19,15 @@ import java.util.function.Function;
  * Does not support polymorphism and does not need '_class' fields either.
  */
 public class CachedEncryptionEventListener extends AbstractEncryptionEventListener<CachedEncryptionEventListener> {
-    ReflectionCache reflectionCache = new ReflectionCache();
+    final ReflectionCache reflectionCache;
 
     public CachedEncryptionEventListener(CryptVault cryptVault) {
+        this(cryptVault, FieldEncryptedPredicate.ANNOTATION_PRESENT);
+    }
+
+    public CachedEncryptionEventListener(CryptVault cryptVault, FieldEncryptedPredicate fieldEncryptedPredicate) {
         super(cryptVault);
+        reflectionCache = new ReflectionCache(fieldEncryptedPredicate);
     }
 
     Node node(Class clazz) {

--- a/src/main/java/com/bol/secure/CachedEncryptionEventListener.java
+++ b/src/main/java/com/bol/secure/CachedEncryptionEventListener.java
@@ -3,7 +3,6 @@ package com.bol.secure;
 import com.bol.crypt.CryptVault;
 import com.bol.crypt.DocumentCryptException;
 import com.bol.crypt.FieldCryptException;
-import com.bol.reflection.FieldEncryptedPredicate;
 import com.bol.reflection.Node;
 import com.bol.reflection.ReflectionCache;
 import org.bson.Document;

--- a/src/main/java/com/bol/secure/FieldEncryptedPredicate.java
+++ b/src/main/java/com/bol/secure/FieldEncryptedPredicate.java
@@ -1,6 +1,4 @@
-package com.bol.reflection;
-
-import com.bol.secure.Encrypted;
+package com.bol.secure;
 
 import java.lang.reflect.Field;
 import java.util.function.Predicate;

--- a/src/main/java/com/bol/secure/ReflectionEncryptionEventListener.java
+++ b/src/main/java/com/bol/secure/ReflectionEncryptionEventListener.java
@@ -3,6 +3,7 @@ package com.bol.secure;
 import com.bol.crypt.CryptVault;
 import com.bol.crypt.DocumentCryptException;
 import com.bol.crypt.FieldCryptException;
+import com.bol.reflection.FieldEncryptedPredicate;
 import com.bol.reflection.Node;
 import com.bol.reflection.ReflectionCache;
 import org.bson.Document;
@@ -25,11 +26,17 @@ import static com.bol.reflection.ReflectionCache.isPrimitive;
  * try to match reflection data to it.
  */
 public class ReflectionEncryptionEventListener extends AbstractEncryptionEventListener<ReflectionEncryptionEventListener> {
+
+    final ReflectionCache reflectionCache;
+
     public ReflectionEncryptionEventListener(CryptVault cryptVault) {
-        super(cryptVault);
+        this(cryptVault, FieldEncryptedPredicate.ANNOTATION_PRESENT);
     }
 
-    ReflectionCache reflectionCache = new ReflectionCache();
+    public ReflectionEncryptionEventListener(CryptVault cryptVault, FieldEncryptedPredicate fieldEncryptedPredicate) {
+        super(cryptVault);
+        this.reflectionCache = new ReflectionCache(fieldEncryptedPredicate);
+    }
 
     void cryptDocument(Document document, Class clazz, Function<Object, Object> crypt) {
         List<Node> nodes = reflectionCache.reflectSingle(clazz);

--- a/src/main/java/com/bol/secure/ReflectionEncryptionEventListener.java
+++ b/src/main/java/com/bol/secure/ReflectionEncryptionEventListener.java
@@ -3,7 +3,6 @@ package com.bol.secure;
 import com.bol.crypt.CryptVault;
 import com.bol.crypt.DocumentCryptException;
 import com.bol.crypt.FieldCryptException;
-import com.bol.reflection.FieldEncryptedPredicate;
 import com.bol.reflection.Node;
 import com.bol.reflection.ReflectionCache;
 import org.bson.Document;

--- a/src/test/java/com/bol/system/CryptAssert.java
+++ b/src/test/java/com/bol/system/CryptAssert.java
@@ -1,0 +1,41 @@
+package com.bol.system;
+
+import com.bol.crypt.CryptVault;
+import org.bson.types.Binary;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CryptAssert {
+
+  private final CryptVault cryptVault;
+
+  public CryptAssert(CryptVault cryptVault) {
+    this.cryptVault = cryptVault;
+  }
+
+  /**
+   * simplistic mongodb BSON serialization lengths:
+   * - 10 bytes for wrapping BSONObject prefix
+   * - 1 byte prefix before field name
+   * - field name (1 byte/char)
+   * - 1 byte 0-terminator after field name
+   * - 4 byte prefix before field value
+   * - field value (1byte/char)
+   * - 1 byte 0-terminator after field value
+   * - 2 bytes 0 terminator for wrapping BSONObject
+   * <p>
+   * (e.g. for a single primitive string, 12 extra bytes are added above its own length)
+   */
+  public void assertCryptLength(Object cryptedSecretBinary, int serializedLength) {
+    assertThat(cryptedSecretBinary).isInstanceOf(Binary.class);
+
+    Object cryptedSecretBytes = ((Binary) cryptedSecretBinary).getData();
+
+    assertThat(cryptedSecretBytes).isInstanceOf(byte[].class);
+    byte[] cryptedBytes = (byte[]) cryptedSecretBytes;
+
+    int expectedCryptedLength = cryptVault.expectedCryptedLength(serializedLength);
+    assertThat(cryptedBytes.length).isEqualTo(expectedCryptedLength);
+  }
+
+}

--- a/src/test/java/com/bol/system/field/FieldDetectionEncryptSystemTest.java
+++ b/src/test/java/com/bol/system/field/FieldDetectionEncryptSystemTest.java
@@ -1,0 +1,74 @@
+package com.bol.system.field;
+
+import com.bol.crypt.CryptVault;
+import com.bol.system.CryptAssert;
+import com.bol.system.model.PlainBean;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import javax.annotation.PostConstruct;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+import static org.springframework.data.mongodb.core.query.Query.query;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = {FieldDetectionMongoDBConfiguration.class})
+public class FieldDetectionEncryptSystemTest {
+
+  @Autowired protected MongoTemplate mongoTemplate;
+  @Autowired protected CryptVault cryptVault;
+
+  private CryptAssert cryptAssert;
+
+  @Before
+  public void cleanDb() {
+    mongoTemplate.dropCollection(PlainBean.class);
+  }
+
+  @PostConstruct
+  void postConstruct() {
+    cryptAssert = new CryptAssert(cryptVault);
+  }
+
+  @Test
+  public void simpleEncryption() {
+    PlainBean bean = new PlainBean();
+    bean.nonSensitiveData = "grass is green";
+    bean.sensitiveData = "earth is flat";
+    bean.singleSubBean = new PlainBean.PlainSubBean("grass is green", "earth is flat");
+    bean.subBeans = Collections.singletonList(new PlainBean.PlainSubBean("grass is green", "earth is flat"));
+
+    mongoTemplate.save(bean);
+
+    PlainBean fromDb = mongoTemplate.findOne(query(where("_id").is(bean.id)), PlainBean.class);
+
+    assertThat(fromDb.nonSensitiveData).isEqualTo(bean.nonSensitiveData);
+    assertThat(fromDb.sensitiveData).isEqualTo(bean.sensitiveData);
+    assertThat(fromDb.singleSubBean.sensitiveData).isEqualTo(bean.singleSubBean.sensitiveData);
+    assertThat(fromDb.singleSubBean.nonSensitiveData).isEqualTo(bean.singleSubBean.nonSensitiveData);
+    assertThat(fromDb.subBeans.get(0).sensitiveData).isEqualTo(bean.subBeans.get(0).sensitiveData);
+    assertThat(fromDb.subBeans.get(0).nonSensitiveData).isEqualTo(bean.subBeans.get(0).nonSensitiveData);
+
+    Document fromMongo = mongoTemplate.getCollection(PlainBean.MONGO_PLAINBEAN).find(new Document("_id", new ObjectId(bean.id))).first();
+    assertThat(fromMongo.get("nonSensitiveData")).isEqualTo(bean.nonSensitiveData);
+    cryptAssert.assertCryptLength(fromMongo.get("sensitiveData"), bean.sensitiveData.length() + 12);
+
+    Document subBeanDocument = (Document)fromMongo.get("singleSubBean");
+    assertThat(subBeanDocument.get("nonSensitiveData")).isEqualTo(bean.singleSubBean.nonSensitiveData);
+    cryptAssert.assertCryptLength(subBeanDocument.get("sensitiveData"), bean.singleSubBean.sensitiveData.length() + 12);
+
+    Document nested = fromMongo.getList("subBeans", Document.class).get(0);
+    assertThat(nested.get("nonSensitiveData")).isEqualTo(bean.subBeans.get(0).nonSensitiveData);
+    cryptAssert.assertCryptLength(nested.get("sensitiveData"), bean.subBeans.get(0).sensitiveData.length() + 12);
+  }
+
+}

--- a/src/test/java/com/bol/system/field/FieldDetectionMongoDBConfiguration.java
+++ b/src/test/java/com/bol/system/field/FieldDetectionMongoDBConfiguration.java
@@ -1,0 +1,31 @@
+package com.bol.system.field;
+
+import com.bol.crypt.CryptVault;
+import com.bol.secure.FieldEncryptedPredicate;
+import com.bol.secure.ReflectionEncryptionEventListener;
+import com.bol.system.MongoDBConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+@Configuration
+public class FieldDetectionMongoDBConfiguration extends MongoDBConfiguration {
+
+    private final Set<String> fields = new HashSet<>(
+      Arrays.asList("PlainBean.sensitiveData", "PlainSubBean.sensitiveData"));
+
+    @Bean
+    public ReflectionEncryptionEventListener encryptionEventListener(CryptVault cryptVault) {
+        return new ReflectionEncryptionEventListener(cryptVault, new FieldEncryptedPredicate() {
+            @Override
+            public boolean test(Field field) {
+                String fieldName = field.getDeclaringClass().getSimpleName() + "." + field.getName();
+                return fields.contains(fieldName);
+            }
+        });
+    };
+}

--- a/src/test/java/com/bol/system/model/PlainBean.java
+++ b/src/test/java/com/bol/system/model/PlainBean.java
@@ -1,0 +1,36 @@
+package com.bol.system.model;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.bol.system.model.PlainBean.MONGO_PLAINBEAN;
+
+@Document(collection = MONGO_PLAINBEAN)
+public class PlainBean {
+  public static final String MONGO_PLAINBEAN = "plainBean";
+
+  @Id public String id;
+
+  @Field public String nonSensitiveData;
+  @Field public String sensitiveData;
+
+  public PlainSubBean singleSubBean;
+  public List<PlainSubBean> subBeans = new ArrayList<>();
+
+  public static class PlainSubBean {
+    @Field public String nonSensitiveData;
+    @Field public String sensitiveData;
+
+    public PlainSubBean() {}
+    public PlainSubBean(String nonSensitiveData, String sensitiveData) {
+      this.nonSensitiveData = nonSensitiveData;
+      this.sensitiveData = sensitiveData;
+    }
+  }
+
+}
+


### PR DESCRIPTION
The change leaves the decision whether the field should be encrypted to the FieldEncryptedPredicate interface. It supports use cases in which enriching the original entity is not optimal.

The original, annotation based strategy has been preserved as default (backwards compatible)



